### PR TITLE
Fix global timezone offset not updating date placeholders correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 - Added configurable flip interval for {flip} placeholder [#69].
 - Added option to launch app on widget click instead of calendar [#73].
 - Fixed timezone offset calculation for positive offsets [#1].
+- Fixed global timezone offset not updating date placeholders correctly [#82].
 - Added `|` as placeholder separator for modifiers (e.g. `{hh|U}`) and `{flip}` (allows `:` in values).
 - Added per-placeholder timezone offset support using `|` separator (e.g. `{hh|+09:00}`) [#1].
 

--- a/src/contents/js/DateTimeFormatter.js
+++ b/src/contents/js/DateTimeFormatter.js
@@ -191,8 +191,7 @@ function format(template, localeName, tzOffset = null) {
 
 	var now = new Date()
 	if (tzOffset !== null) {
-		var offsetInMillis = tzOffset * 60 * 1000
-		now = new Date(now.valueOf() + offsetInMillis)
+		now = new Date(now.valueOf() + (tzOffset + now.getTimezoneOffset()) * 60 * 1000)
 	}
 
 	// Build map for current/offset time


### PR DESCRIPTION
## Summary
- Fixed global timezone offset calculation not properly accounting for local timezone
- Date placeholders now correctly update when timezone offset crosses midnight

Fixes #82