### PR TITLE
Remove padding above widget on thin toolbars

### DIFF
--- a/src/contents/ui/HtmlClock.qml
+++ b/src/contents/ui/HtmlClock.qml
@@ -19,6 +19,7 @@ import "../js/utils.js" as Utils
 
 ColumnLayout {
 	id: mainContainer
+	spacing: 0
 
 	// Signal to notify parent to toggle expanded state
 	signal toggleExpanded()


### PR DESCRIPTION
## Summary
- Added `spacing: 0` to ColumnLayout in HtmlClock.qml to remove extra padding above the widget on thin panels/toolbars

Fixes #108